### PR TITLE
Patch for double URL encoding bug

### DIFF
--- a/src/tailrecursion/ring_proxy.clj
+++ b/src/tailrecursion/ring_proxy.clj
@@ -33,10 +33,10 @@
                               (.getAuthority uri)
                               (str (.getPath uri)
                                    (subs (:uri req) (.length proxied-path)))
-                              (:query-string req)
+                              nil
                               nil)]
          (-> {:method (:request-method req)
-              :url (str remote-uri)
+              :url (str remote-uri "?" (:query-string req))
               :headers (dissoc (:headers req) "host" "content-length")
               :body (if-let [len (get-in req [:headers "content-length"])]
                       (slurp-binary (:body req) (Integer/parseInt len)))


### PR DESCRIPTION
Using this library I encountered an issue where the proxy forwarded requests were generating errors on the recieving server due it seemed to malformed url parameters. Upon inspection I realized that (:query-string) is still url-encoded, so if it is passed directly to (URI.) which is then stringified the parameters part will be urlencoded twice. Due to the URLencode of "%20" being "%2520", this is a clear source of proxy'd request failures.

One possible fix, and the one I have live and propose here is to just concatenate the already URL-encoded parameters and the parameter prefix "?" to the end of the computed new URI.
