### PR TITLE
Allow proxying of multi packet data.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,9 @@
-(defproject tailrecursion/ring-proxy "2.0.0-SNAPSHOT"
+(defproject tailrecursion/ring-proxy "4.0.2-FINAL"
   :description "HTTP proxy ring middleware for Clojure web applications."
   :url "https://github.com/tailrecursion/ring-proxy"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [ring/ring-core "1.1.8"]
-                 [clj-http "0.6.5"]])
+                 [clj-http "0.6.5"]]
+:repositories [["releases" {:url "http://nexus-dev.snc1/content/repositories/releases/" :sign-releases false}]])

--- a/src/tailrecursion/ring_proxy.clj
+++ b/src/tailrecursion/ring_proxy.clj
@@ -16,12 +16,7 @@
 (defn slurp-binary
   "Reads len bytes from InputStream is and returns a byte array."
   [^java.io.InputStream is len]
-  (with-open [rdr is]
-    (let [buf (byte-array len)]
-      (loop [bytes-read (.read rdr buf)]
-        (if (= bytes-read -1)
-          buf
-          (recur (.read rdr buf)))))))
+  (slurp is))
 
 (defn wrap-proxy
   "Proxies requests to proxied-path, a local URI, to the remote URI at
@@ -37,7 +32,7 @@
                                    (subs (:uri req) (.length proxied-path)))
                               nil
                               nil)]
-         (-> (merge {:method (:request-method req)
+         (-> (merge-with merge {:method (:request-method req)
                      :url (str remote-uri "?" (:query-string req))
                      :headers (dissoc (:headers req) "host" "content-length")
                      :body (if-let [len (get-in req [:headers "content-length"])]


### PR DESCRIPTION
When dealing with multi-packet data, the current implementation truncates as `read` only reads a portion of the buffer. According to the [documentation](http://docs.oracle.com/javase/6/docs/api/java/io/InputStream.html#read%28byte[]%29), `read` should be called until it returns `-1` number of bytes read.
