### PR TITLE
remove 'Transfer-Encoding' from headers

### DIFF
--- a/src/tailrecursion/ring_proxy.clj
+++ b/src/tailrecursion/ring_proxy.clj
@@ -46,6 +46,7 @@
                      :throw-exceptions false
                      :as :stream} http-opts)
              request
+             (update :headers dissoc "Transfer-Encoding")
              prepare-cookies))
        (handler req)))))
 


### PR DESCRIPTION
I got a compressed chunked response from my remote and i had to remove the 'Transfer-Encoding' header from my response to make it work.
