### PR TITLE
use clj-http's wrap-cookies instead of ring's because formats have diverged

### DIFF
--- a/src/tailrecursion/ring_proxy.clj
+++ b/src/tailrecursion/ring_proxy.clj
@@ -3,9 +3,9 @@
     [java.net URI] )
   (:require
     [clj-http.client         :refer [request]]
+    [clj-http.cookies        :refer [wrap-cookies]]
     [clojure.string          :refer [join split]]
-    [ring.adapter.jetty      :refer [run-jetty]]
-    [ring.middleware.cookies :refer [wrap-cookies]] ))
+    [ring.adapter.jetty      :refer [run-jetty]]))
 
 (defn prepare-cookies
   "Removes the :domain and :secure keys and converts the :expires key (a Date)


### PR DESCRIPTION
This switches to use clj-http's `wrap-cookies` instead of ring's because their formats have diverged. clj-http returns cookies something like this:

```
{:discard true, :expires , :path /, :version 0, :value ...}
```

but ring no longer accepts `:discard` and `:version` as shown here: https://github.com/ring-clojure/ring/commit/c05004fcb2227e75f2299ac7e6d8d9a4aefdb002#diff-c055e0aeef031084c68bf6da304ed4f7L25

This leads to the following error when there is cookie info in the response:

```
java.lang.AssertionError: Assert failed: (every? valid-attr? attrs)
```
