### PR TITLE
Add bootlaces on top of other PR

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -9,6 +9,7 @@
 (require '[adzerk.bootlaces :refer :all])
 
 (def +version+ "3.0.0-SNAPSHOT")
+(bootlaces! +version+)
 
 (task-options!
   pom  {:project     'tailrecursion/ring-proxy

--- a/src/tailrecursion/ring_proxy.clj
+++ b/src/tailrecursion/ring_proxy.clj
@@ -3,9 +3,9 @@
     [java.net URI] )
   (:require
     [clj-http.client         :refer [request]]
+    [clj-http.cookies        :refer [wrap-cookies]]
     [clojure.string          :refer [join split]]
-    [ring.adapter.jetty      :refer [run-jetty]]
-    [ring.middleware.cookies :refer [wrap-cookies]] ))
+    [ring.adapter.jetty      :refer [run-jetty]]))
 
 (defn prepare-cookies
   "Removes the :domain and :secure keys and converts the :expires key (a Date)


### PR DESCRIPTION
This just adds `(bootlaces! +version+)` on top of my previous PR (https://github.com/tailrecursion/ring-proxy/pull/15). I had to add it to get `boot build-jar push-snapshot` to work. I'm doing it as a separate PR because I suspect you guys left it out intentionally for some reason (I know you guys did write boot...).
